### PR TITLE
Using .NET 6.0 docker images instead of 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ energy_over_day.txt
 obj/
 bin/
 .DS_Store
+docker-compose.yml
+src/config.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/microsoft-dotnet
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -11,7 +11,7 @@ COPY src/ ./
 RUN dotnet publish -c release -o /app --no-restore
 
 # final stage/image
-FROM mcr.microsoft.com/dotnet/aspnet:5.0
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 RUN apt-get update \
   && apt-get install -y python3 python3-pip \
   && pip3 install requests


### PR DESCRIPTION
After targeting .NET 6.0, building with docker-compose build did no longer work using .NET 5.0 images.
I also added files I had edited with peronal information (src/config.py and password in docker-compose) to .gitignore.